### PR TITLE
revisão do estilo TheOne

### DIFF
--- a/theOne.lua
+++ b/theOne.lua
@@ -234,3 +234,4 @@ theOne:bind(removeStopWords)
 theOne:bind(frequencies)
 theOne:bind(top25SortedFrequencies)
 theOne:printSelf()
+-- ver comentarios no pull-request


### PR DESCRIPTION
argumentar porque a função TheOne naõ implementa o bind e o printme como é feito no estilo.
´´´
class TFTheOne:
    def __init__(self, v):
         self._value = v

   def bind(self, func):
         self._value = func(self._value)
         return self

def printme(self):
      print self._value
```
rever linha 228, deve ler qualquer texto:
```
local theOne = TheOne.new(arg[1])
```
o resultado não é o correto. No codigo da crista as palavras com frequencia 3 saõ diferentes
![the-one-hugo-jordan](https://user-images.githubusercontent.com/1106435/27298980-93b1d572-54df-11e7-87e5-e051d06412e4.png)