### PR TITLE
revisão Things

### DIFF
--- a/things.lua
+++ b/things.lua
@@ -225,3 +225,4 @@ function WordFrequencyController:run()
 end
 
 WordFrequencyController.new("text.txt"):run()
+--ver comentarios no pull-request


### PR DESCRIPTION
Argumentar porque o metodo para separar (split) um texto em palavras, é feito separadamente. No estilo Things,  todas as ações relacionadas à filtragem do texto estão dentro do DataStoreManager (ver embaixo codigo do livro)

```
class DataStorageManager(TFExercise):
    """ Models the contents of the file """
    
    def __init__(self, path_to_file):
        with open(path_to_file) as f:
            self._data = f.read()
        pattern = re.compile('[\W_]+')
        self._data = pattern.sub(' ', self._data).lower()

    def words(self):
        """ Returns the list words in storage """
        return self._data.split()

    def info(self):
return super(DataStorageManager, self).info() + ": My major data structure is a " + self._data.__class__.__name__
```
vocẽs tem duas funções para resolver isto:

```
function DataStorageManager.new(pathToFile)
function DataStorageManager:words()
```

favor vejam como o setmetatable é tratado aqui http://lua-users.org/wiki/MetamethodsTutorial, a ideia é fazer um codigo que esteja deacordo à restrição do estilo

```
-- pag 83 do livro
Each thing is a capsule of data that exposes procedures to the rest of the world.
```